### PR TITLE
Rename module in mix.exs not to conflict with Protobuf package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule Protobuf.Mixfile do
+defmodule ExProtobuf.Mixfile do
   use Mix.Project
 
   def project do


### PR DESCRIPTION
This is one final step in renaming the package to `ExProtobuf`. Without this change mix gets confused (a bug perhaps) and leaves either `protobuf` or `exprotobuf` directory empty within `_build/dev/lib`. This, in turn, leads to problemp during local compilation with either "module ExProtobuf is not loaded and could not be found" or more cryptic with modules defined from `.proto` files not being found.